### PR TITLE
Update Molex connector model

### DIFF
--- a/bose-qc35-usb-c.kicad_pcb
+++ b/bose-qc35-usb-c.kicad_pcb
@@ -249,7 +249,7 @@
         (effects (font (size 1 1) (thickness 0.15)))
       (tstamp 452429de-72ab-449f-b8c3-d248aea2521a)
     )
-    (fp_text value "51281-0594" (at 0 2.05 90) (layer "Dwgs.User")
+    (fp_text value "51281-0598" (at 0 2.05 90) (layer "Dwgs.User")
         (effects (font (size 0.5 0.5) (thickness 0.08)))
       (tstamp dcfa14b5-60b3-4c9a-a338-9d0564b0e8ac)
     )

--- a/bose-qc35-usb-c.kicad_sch
+++ b/bose-qc35-usb-c.kicad_sch
@@ -2603,7 +2603,7 @@
     (property "Reference" "J3" (at 267.462 45.9232 0)
       (effects (font (size 1.27 1.27)) (justify left))
     )
-    (property "Value" "51281-0594" (at 267.462 48.2346 0)
+    (property "Value" "51281-0598" (at 267.462 48.2346 0)
       (effects (font (size 1.27 1.27)) (justify left))
     )
     (property "Footprint" "Connector_FFC-FPC:TE_0-1734839-5_1x05-1MP_P0.5mm_Horizontal" (at 265.43 46.99 0)

--- a/library.pretty/TE_0-1734839-5_1x05-1MP_P0.5mm_Horizontal.kicad_mod
+++ b/library.pretty/TE_0-1734839-5_1x05-1MP_P0.5mm_Horizontal.kicad_mod
@@ -11,7 +11,7 @@
       (effects (font (size 1 1) (thickness 0.15)))
     (tstamp 77e4f132-9a3c-403a-9475-beef11a4eb5c)
   )
-  (fp_text value "51281-0594" (at 0 2.05) (layer "Dwgs.User")
+  (fp_text value "51281-0598" (at 0 2.05) (layer "Dwgs.User")
       (effects (font (size 0.5 0.5) (thickness 0.08)))
     (tstamp 59c20f46-e206-4fda-a6b0-4f09bd048ab3)
   )


### PR DESCRIPTION
This connector (model `0512810594` or `051281-0594` depending on styling) has been obsoleted by Molex, and has been replaced by model `512810598` (or `51281-0598`).

Reference: https://www.molex.com/en-us/products/part-detail/0512810594