### PR TITLE
increase C1 capacitance

### DIFF
--- a/bose-qc35-usb-c.kicad_sch
+++ b/bose-qc35-usb-c.kicad_sch
@@ -3237,7 +3237,7 @@
     (property "Reference" "C1" (at 148.3868 47.7266 0)
       (effects (font (size 1.27 1.27)) (justify left))
     )
-    (property "Value" "4u7" (at 148.3868 50.038 0)
+    (property "Value" "22u" (at 148.3868 50.038 0)
       (effects (font (size 1.27 1.27)) (justify left))
     )
     (property "Footprint" "Capacitor_SMD:C_0402_1005Metric" (at 146.05 48.895 0)


### PR DESCRIPTION
see second half of https://log.desmas.net/2021/10/19/audio-electronics-repair.html

datasheet recommends 20+ µF, I have no idea how Bose landed on 4.7µF but it barely registers on the chart, and I suspect this w/ lower voltage tolerance part led to my short.

![image](https://github.com/user-attachments/assets/82e1a986-922e-4b75-8dcd-7fbc5dbd5016)

